### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,7 @@ Feed module enables everyone to have RSS, Atom and JSON.
 1. Add `nuxt-module-feed` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-module-feed
-
-# Using yarn
-yarn add --dev nuxt-module-feed
-
-# Using npm
-npm install --save-dev nuxt-module-feed
+npx nuxi@latest module add module-feed
 ```
 
 2. Add `nuxt-module-feed` to the `modules` section of `nuxt.config.ts`


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
