### PR TITLE
fix: prefer `nitro.static` over `_generate`

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -23,7 +23,7 @@ export default defineNuxtModule<ModuleOptions>({
       })
 
       // Handle SSG
-      if (nuxt.options._generate) {
+      if (nuxt.options.nitro.static || (nuxt.options as any)._generate /* TODO: remove in future */) {
         addPrerenderRoutes([source.path])
       }
 


### PR DESCRIPTION

Since nuxi v3.8, we've supported setting `nuxt.options.nitro.static` instead of `nuxt.options._generate` (which is an internal flag) - see https://github.com/nuxt/nuxt/pull/21860.

Now, in preparation for Nuxt v4, we've removed the types for `_generate` (see https://github.com/nuxt/nuxt/pull/32355). This PR adds support for new version in backwards compatible way (ignoring type issues) - I'd suggest you remove support in a future major.